### PR TITLE
Fix "AttributeError: module 'OpenSSL.crypto' has no attribute 'PKCS12'"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,10 @@ six
 charset_normalizer
 pyasn1>=0.2.3
 pycryptodomex
-pyOpenSSL>=21.0.0
+pyOpenSSL==22.1.0
 ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6
 ldapdomaindump>=0.9.0
 flask>=1.0
 pyreadline;sys_platform == 'win32'
 dsinternals
+setuptools


### PR DESCRIPTION
Current pyOpenSSL version fails:
<img width="1496" alt="image" src="https://github.com/user-attachments/assets/759e6a6b-bc6b-400e-8581-13c76e18e37a" />

Version 22.1.0 works fine.

Plus, added "setuptools" to requirements.txt for newer Python versions.